### PR TITLE
8 - Readonly 2

### DIFF
--- a/questions/00008-medium-readonly-2/template.ts
+++ b/questions/00008-medium-readonly-2/template.ts
@@ -1,1 +1,6 @@
-type MyReadonly2<T, K> = any
+type MyReadonly2<T, K extends keyof T = keyof T> =
+  {
+    [key in keyof T as key extends K ? never : key]: T[key]
+  } & {
+    readonly [key in K]: T[key]
+  }


### PR DESCRIPTION
- build an object from keys not in the second parameter
- build a `readonly` object from keys that are in the second parameter
- combine

also need to set a default for the second parameter for the first test case to pass as it only provides one argument